### PR TITLE
fix: add interface IStickyHeader.

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -8,7 +8,7 @@ android {
 
     defaultConfig {
         applicationId "com.kongnan.headerscrollview"
-        minSdkVersion 23
+        minSdkVersion 21
         targetSdkVersion 34
         versionCode 1
         versionName "1.0"

--- a/app/src/main/java/com/kongnan/headerscrollview/HeaderScrollView.kt
+++ b/app/src/main/java/com/kongnan/headerscrollview/HeaderScrollView.kt
@@ -46,7 +46,10 @@ class HeaderScrollView @JvmOverloads constructor(
      */
     private val contentViewHeight get() = if (contentView.isVisible) measuredHeight + headViewHeight - headViewMinHeight else measuredHeight
 
-    private val headViewMinHeight get() = if (headView.isVisible) headView.minimumHeight else 0
+    /**
+     * headView的最小高度，即最后一个吸顶View的高度
+     */
+    private val headViewMinHeight get() = if (headView.isVisible) (headView as IStickyHeader).lastStickyHeight else 0
 
     override fun onFinishInflate() {
         super.onFinishInflate()
@@ -54,10 +57,10 @@ class HeaderScrollView @JvmOverloads constructor(
         if (childView.childCount == 2) {
             headView = childView.getChildAt(0) as ViewGroup
             contentView = childView.getChildAt(1) as ViewGroup
-            isStickyLayout = headView is View.OnScrollChangeListener
+            isStickyLayout = headView is IStickyHeader
             if (isStickyLayout) {
                 headView.addOnLayoutChangeListener { _, _, _, _, _, _, _, _, _ ->
-                    (headView as View.OnScrollChangeListener).onScrollChange(this, scrollX, scrollY, scrollX, scrollY)
+                    (headView as IStickyHeader).onHeaderScrollChange(this, scrollX, scrollY, scrollX, scrollY)
                 }
             }
         } else {
@@ -90,12 +93,12 @@ class HeaderScrollView @JvmOverloads constructor(
     }
 
     override fun onOverScrolled(scrollX: Int, scrollY: Int, clampedX: Boolean, clampedY: Boolean) {
-        val scrollMax = headViewHeight - headView.minimumHeight
+        val scrollMax = headViewHeight - headViewMinHeight
         super.onOverScrolled(scrollX, min(scrollMax, scrollY), clampedX, clampedY)
     }
 
     override fun scrollTo(x: Int, y: Int) {
-        val scrollMax = headViewHeight - headView.minimumHeight
+        val scrollMax = headViewHeight - headViewMinHeight
         super.scrollTo(x, min(scrollMax, y))
     }
 
@@ -103,7 +106,7 @@ class HeaderScrollView @JvmOverloads constructor(
         val isParentScroll = dispatchNestedPreScroll(dx, dy, consumed, null, type)
         if (!isParentScroll) {
             // 向上滑动且当前滑动距离小于顶部视图的高度时，需要此控件滑动响应的距离以保证滑动连贯性
-            val needKeepScroll = dy > 0 && scrollY < (headViewHeight - headView.minimumHeight)
+            val needKeepScroll = dy > 0 && scrollY < (headViewHeight - headViewMinHeight)
             if (needKeepScroll) {
                 needInvalidate = true
                 scrollBy(0, dy)
@@ -129,7 +132,7 @@ class HeaderScrollView @JvmOverloads constructor(
     override fun onScrollChanged(l: Int, t: Int, oldl: Int, oldt: Int) {
         super.onScrollChanged(l, t, oldl, oldt)
         if (isStickyLayout) {
-            (headView as View.OnScrollChangeListener).onScrollChange(this, l, t, oldl, oldt)
+            (headView as IStickyHeader).onHeaderScrollChange(this, l, t, oldl, oldt)
         }
     }
 

--- a/app/src/main/java/com/kongnan/headerscrollview/IStickyHeader.java
+++ b/app/src/main/java/com/kongnan/headerscrollview/IStickyHeader.java
@@ -1,0 +1,9 @@
+package com.kongnan.headerscrollview;
+
+import android.view.View;
+
+public interface IStickyHeader {
+    void onHeaderScrollChange(View v, int scrollX, int scrollY, int oldScrollX, int oldScrollY);
+
+    int getLastStickyHeight();
+}

--- a/app/src/main/java/com/kongnan/headerscrollview/StickyLinearLayout.kt
+++ b/app/src/main/java/com/kongnan/headerscrollview/StickyLinearLayout.kt
@@ -9,13 +9,14 @@ import kotlin.math.max
 
 class StickyLinearLayout @JvmOverloads constructor(
     context: Context, attrs: AttributeSet? = null, defStyleAttr: Int = 0
-) : LinearLayout(context, attrs, defStyleAttr), View.OnScrollChangeListener {
+) : LinearLayout(context, attrs, defStyleAttr),
+    IStickyHeader {
 
     init {
         isChildrenDrawingOrderEnabled = true
     }
 
-    override fun onScrollChange(v: View, scrollX: Int, scrollY: Int, oldScrollX: Int, oldScrollY: Int) {
+    override fun onHeaderScrollChange(v: View, scrollX: Int, scrollY: Int, oldScrollX: Int, oldScrollY: Int) {
         var isFixed = false
         var isNext = true
         var previousOffset = 0
@@ -41,8 +42,12 @@ class StickyLinearLayout @JvmOverloads constructor(
         }
     }
 
-    private fun nextStickyView(index: Int): View? {
-        for (i in index - 1 downTo 0) {
+    override fun getLastStickyHeight(): Int {
+        return lastStickyView()?.measuredHeight ?: 0
+    }
+
+    private fun lastStickyView(): View? {
+        for (i in childCount - 1 downTo 0) {
             val child = getChildAt(i)
             val offsetHelper = getViewOffsetHelper(child)
             if (offsetHelper != null) {
@@ -52,17 +57,15 @@ class StickyLinearLayout @JvmOverloads constructor(
         return null
     }
 
-    override fun onMeasure(widthMeasureSpec: Int, heightMeasureSpec: Int) {
-        super.onMeasure(widthMeasureSpec, heightMeasureSpec)
-        var minHeight = 0
-        for (i in childCount - 1 downTo 0) {
+    private fun nextStickyView(index: Int): View? {
+        for (i in index - 1 downTo 0) {
             val child = getChildAt(i)
-            if ((child.layoutParams as LayoutParams).isSticky) {
-                minHeight = child.measuredHeight
-                break
+            val offsetHelper = getViewOffsetHelper(child)
+            if (offsetHelper != null) {
+                return child
             }
         }
-        minimumHeight = minHeight
+        return null
     }
 
     override fun onLayout(changed: Boolean, left: Int, top: Int, right: Int, bottom: Int) {


### PR DESCRIPTION
通过IStickyHeader接口，实现以下功能：
   
    1. 支持minSdkVersion=21(android 5.0);
    2. 不占用原生minHeight属性;
    3. 修复header可见行为gone滑动到底部的滑动问题（scrollTo相关计算修复）